### PR TITLE
ajout Notebook 2

### DIFF
--- a/notebooks/02-types-et-structures.ipynb
+++ b/notebooks/02-types-et-structures.ipynb
@@ -393,7 +393,7 @@
         "vote =\n",
         "twitter =\n",
         "\n",
-        "# Créez un nouvel objet nommé `pokemon_2` contenant les valeurs pour Pokemon2.\n",
+        "# Créez un nouvel objet nommé `repondant_2` contenant les valeurs pour ce nouveau répondant.\n",
         "repondant_2 = [age, genre, pays, travaille, vote, twitter]"
       ]
     },
@@ -661,7 +661,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv (3.13.1)",
+      "display_name": "data-viz (3.13.1)",
       "language": "python",
       "name": "python3"
     },


### PR DESCRIPTION
Ajout du notebook 2. Traduction du notebook anglais (amélioration depuis la trad utilisée lors de l'inititation python à dataSHS) et utilisation de données fictives types données électorales plutôt que des exemples pokemon.