### PR TITLE
correction colab compatibility for milestone-1

### DIFF
--- a/notebooks/milestone-1.ipynb
+++ b/notebooks/milestone-1.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "## 🎯 ZONE DE TRAVAIL - MODIFICATIONS REQUISES\n",
     "\n",
-    "Commencez par executer la cellule ci-dessous (certaines des bibliothèques nécessaires ne sont pas pré-installées dans collab, nous devons donc le faire nous-même) :"
+    "Commencez par executer la cellule ci-dessous (certaines des bibliothèques nécessaires ne sont pas pré-installées dans colab, nous devons donc le faire nous-même) :"
    ]
   },
   {


### PR DESCRIPTION
Le notebook milestone-1 foirait dans colab (sans doute le `alt.data_transformers.enable("vegafusion")` qu'on avait pas testé jusque là et qui a besoin de packages non pré-installés)

- ajout d'un %pip install pour pouvoir exécuter le notebook dans colab
```(%pip install "vegafusion[embed]>=1.5.0" "vl-convert-python>=1.6.0")```
- modif des cellules/formulations pour que ce soit clair pour les étudiants
- j'ai séparé le pip et le code en deux cellules : même si avec une magic %pip ça marcherait dans une seule cellule, les étudiants vont la triturer et la relancer plein de fois, ça me semble mieux de séparer que d'avoir tout ré-affiché à chaque exécution.